### PR TITLE
SmashNight, Match, and Youtube cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Try
 
 If there is no version installed, follow the instructions to install it
 
-### Step 3: Run quick to start the dev container
+### Step 3: Run qs to start the dev container
 
 This one is super easy but might take a minute. Just run:
 

--- a/qs
+++ b/qs
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
+set -e
 category=$1
 # Possible categories
 # run, stop, backup
 
 ## Container Commands ##
-if [ $category == "run" ] || [ $category == "stop" ]; then
+if [ $category == "run" ] || [ $category == "stop" ] || [ $category == "restart" ]; then
     compose_args=("--env-file")
     post_args=()
     dev_type=$2
@@ -25,6 +26,9 @@ if [ $category == "run" ] || [ $category == "stop" ]; then
         . $env_file && post_args+=("echo" "Application available at http://localhost:${ACCESS_PORT}")
     elif [ $category == "stop" ]; then
         compose_args+=("down")
+    elif [ $category == "restart" ]; then
+        compose_args+=("restart")
+        . $env_file && post_args+=("echo" "Application available at http://localhost:${ACCESS_PORT}")
     fi
     extra_args=${@:3}
     docker compose ${compose_args[@]} ${extra_args[@]}

--- a/sncrs/data/admin.py
+++ b/sncrs/data/admin.py
@@ -3,6 +3,8 @@ from django.contrib import messages
 from django.utils.translation import ngettext
 from django.shortcuts import render
 
+from itertools import chain
+
 from .models import *
 from .forms import TeamForm, StageTypeForm, MatchupTypeForm
 from .sn_calculate import full_update
@@ -66,7 +68,10 @@ class SmashNightAdmin(admin.ModelAdmin):
     def show_youtube_details(self, request, queryset):
         details = []
         for sn in queryset.order_by('-date'):
-            for match in sn.match_set.all():
+            for match in chain(
+                sn.match_set.filter(bracket__isnull=False).order_by('-bracket__rank', 'round'),
+                sn.match_set.filter(bracket__isnull=True)
+            ):
                 details.append("Title: {}".format(match.title))
                 details.append("Description: {}".format(match.description))
                 details.append("-------------------------")

--- a/sncrs/data/admin.py
+++ b/sncrs/data/admin.py
@@ -6,7 +6,7 @@ from django.shortcuts import render
 from .models import *
 from .forms import TeamForm, StageTypeForm, MatchupTypeForm
 from .sn_calculate import full_update
-from .youtube_logic import get_titles_and_descriptions, set_videos
+from .youtube_logic import set_videos
 # Register your models here.
 
 
@@ -66,10 +66,9 @@ class SmashNightAdmin(admin.ModelAdmin):
     def show_youtube_details(self, request, queryset):
         details = []
         for sn in queryset.order_by('-date'):
-            items = get_titles_and_descriptions(sn)
-            for item in items:
-                details.append("Title: {}".format(item["Title"]))
-                details.append("Description: {}".format(item["Description"]))
+            for match in sn.match_set.all():
+                details.append("Title: {}".format(match.title))
+                details.append("Description: {}".format(match.description))
                 details.append("-------------------------")
         context = {
             "list": details,

--- a/sncrs/data/api.py
+++ b/sncrs/data/api.py
@@ -1,11 +1,12 @@
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
 
-from data.views import MatchList, SnapshotList
+from data.views import MatchList, SnapshotList, SmashNightList
 
 urlpatterns = [
     path('matches/', MatchList.as_view(), name='matches'),
     path('snapshots/', SnapshotList.as_view(), name='snapshots'),
+    path('smashnights/', SmashNightList.as_view(), name='smashnights'),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/sncrs/data/filters.py
+++ b/sncrs/data/filters.py
@@ -1,12 +1,13 @@
 from django_filters import rest_framework as filters
 from django.db.models import Q
 
-from data.models import Match, PersonSnapshot
+from data.models import Match, PersonSnapshot, SmashNight
 
 class MatchFilter(filters.FilterSet):
     chat_tag = filters.CharFilter(label='chat_tag', field_name='chat_tag', method='both_players_filter')
     player = filters.CharFilter(label='player', field_name='display_name', method='both_players_filter')
     season = filters.CharFilter(label='season', field_name='sn__season')
+    sn_title = filters.CharFilter(label='sn_title', field_name='short_title', method='short_title_filter')
 
     class Meta:
         model = Match
@@ -32,6 +33,10 @@ class MatchFilter(filters.FilterSet):
             filtered_set = self.both_players_filter_single(filtered_set, name, player)
         return filtered_set
     
+    def short_title_filter(self, queryset, name, value):
+        sn = SmashNight.objects.filter(**{name: value}).first()
+        return queryset.filter(Q(sn=sn))
+    
 class SnapshotFilter(filters.FilterSet):
     chat_tag = filters.CharFilter(label='chat_tag', field_name="person__chat_tag")
     player = filters.CharFilter(label='player', field_name="person__display_name")
@@ -40,4 +45,13 @@ class SnapshotFilter(filters.FilterSet):
         model = PersonSnapshot
         fields = [
             'sn',
+        ]
+
+class SmashNightFilter(filters.FilterSet):
+    short_title = filters.CharFilter(label='short_title', field_name="short_title")
+
+    class Meta:
+        model = SmashNight
+        fields = [
+            'night_count',
         ]

--- a/sncrs/data/filters.py
+++ b/sncrs/data/filters.py
@@ -4,27 +4,33 @@ from django.db.models import Q
 from data.models import Match, PersonSnapshot
 
 class MatchFilter(filters.FilterSet):
-    chat_tag = filters.CharFilter(label='chat_tag', method='both_chat_tags')
-    player = filters.CharFilter(label='player', method='both_players')
+    chat_tag = filters.CharFilter(label='chat_tag', field_name='chat_tag', method='both_players_filter')
+    player = filters.CharFilter(label='player', field_name='display_name', method='both_players_filter')
+    season = filters.CharFilter(label='season', field_name='sn__season')
 
     class Meta:
         model = Match
         fields = [
             'sn',
-            'chat_tag',
             'match_url',
-            'player'
         ]
     
-    def both_chat_tags(self, queryset, name, value):
-        return queryset.filter(
-            Q(p1__chat_tag=value) | Q(p2__chat_tag=value)
-        )
+    def both_players_filter_single(self, queryset, name, value):
+        """Create a query filtering both p1 and p2 on the field
+        specified by field_name, for the value in value"""
+        player = value
+        p1_arg = {f'p1__{name}': player}
+        p2_arg = {f'p2__{name}': player}
+        return queryset.filter(Q(**p1_arg) | Q(**p2_arg))
     
-    def both_players(self, queryset, name, value):
-        return queryset.filter(
-            Q(p1__display_name=value) | Q(p2__display_name=value)
-        )
+    def both_players_filter(self, queryset, name, value):
+        """Allow multiple players to be specified by using
+        commas as a separator"""
+        players = value.split(",")
+        filtered_set = queryset
+        for player in players:
+            filtered_set = self.both_players_filter_single(filtered_set, name, player)
+        return filtered_set
     
 class SnapshotFilter(filters.FilterSet):
     chat_tag = filters.CharFilter(label='chat_tag', field_name="person__chat_tag")
@@ -34,6 +40,4 @@ class SnapshotFilter(filters.FilterSet):
         model = PersonSnapshot
         fields = [
             'sn',
-            'chat_tag',
-            'player'
         ]

--- a/sncrs/data/models.py
+++ b/sncrs/data/models.py
@@ -206,9 +206,8 @@ class SmashNight(models.Model):
     def save(self, *args, **kwargs):
         if not self.pk:
             self.night_count = SmashNight.objects.get_latest_night_count() + 1
-            earliest_sn = SmashNight.objects.get_earliest_sn_in_season(self.season)
-            earliest = earliest_sn.night_count if earliest_sn else self.night_count
-            self.title = f"SmashNight Season {self.season} Night {self.night_count + 1 - earliest}"
+            night_in_season = SmashNight.objects.filter(season=self.season).count() + 1
+            self.title = f"SmashNight Season {self.season} Night {night_in_season}"
         super().save(*args, **kwargs)
 
     class Meta:

--- a/sncrs/data/models.py
+++ b/sncrs/data/models.py
@@ -195,8 +195,8 @@ class SmashNightManager(models.Manager.from_queryset(SmashNightQuerySet)):
 class SmashNight(models.Model):
     season = models.IntegerField()
     date = models.DateField()
-    title = models.CharField(max_length=200)
-    night_count = models.IntegerField()
+    title = models.CharField(max_length=200, blank=True, null=True)
+    night_count = models.IntegerField(blank=True, null=True)
     automations_ran = models.BooleanField(default=False)
     objects = SmashNightManager()
 
@@ -206,7 +206,9 @@ class SmashNight(models.Model):
     def save(self, *args, **kwargs):
         if not self.pk:
             self.night_count = SmashNight.objects.get_latest_night_count() + 1
-            self.title = f"Season {self.season} Night {self.get_season_night_count()}"
+            earliest_sn = SmashNight.objects.get_earliest_sn_in_season(self.season)
+            earliest = earliest_sn.night_count if earliest_sn else self.night_count
+            self.title = f"SmashNight Season {self.season} Night {self.night_count + 1 - earliest}"
         super().save(*args, **kwargs)
 
     class Meta:

--- a/sncrs/data/serializers.py
+++ b/sncrs/data/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from data.models import Match, PersonSnapshot
+from data.models import Match, PersonSnapshot, SmashNight
 
 class MatchSerializer(serializers.ModelSerializer):
     class Meta:
@@ -21,6 +21,22 @@ class MatchSerializer(serializers.ModelSerializer):
             'match_url',
             'round',
             'type',
+            ]
+
+class SmashNightSerializer(serializers.ModelSerializer):
+    season_night_count = serializers.ReadOnlyField()
+    short_title = serializers.ReadOnlyField()
+
+    class Meta:
+        model = SmashNight
+        fields = [
+            'id', 
+            'season',
+            'date',
+            'title',
+            'night_count',
+            'season_night_count',
+            'short_title',
             ]
         
 class SnapshotSerializer(serializers.ModelSerializer):

--- a/sncrs/data/views.py
+++ b/sncrs/data/views.py
@@ -3,8 +3,8 @@ from django.db.models import Func, F
 from django.db.models.functions import Lower
 
 from data.models import Match, PersonSnapshot, Person, Team, StageType, SmashNight, Venue
-from data.serializers import MatchSerializer, SnapshotSerializer
-from data.filters import MatchFilter, SnapshotFilter
+from data.serializers import MatchSerializer, SnapshotSerializer, SmashNightSerializer
+from data.filters import MatchFilter, SnapshotFilter, SmashNightFilter
 from rest_framework import generics
 
 
@@ -160,3 +160,8 @@ class SnapshotList(generics.ListAPIView):
     queryset = PersonSnapshot.objects.all()
     serializer_class = SnapshotSerializer
     filterset_class = SnapshotFilter
+
+class SmashNightList(generics.ListAPIView):
+    queryset = SmashNight.objects.all()
+    serializer_class = SmashNightSerializer
+    filterset_class = SmashNightFilter

--- a/sncrs/data/youtube_logic.py
+++ b/sncrs/data/youtube_logic.py
@@ -32,14 +32,13 @@ def get_smashnight_videos(sn):
     youtube = googleapiclient.discovery.build(
         api_service_name, api_version, developerKey=os.environ.get('SNCRS_YOUTUBE_DEV_KEY'))
 
-    current_season_night_count = get_night_count(sn=sn)
-    search_string = "{0}.{1}".format(sn.season, current_season_night_count)
+    title = sn.objects.filter(id=sn.id).first().short_title
 
     request = youtube.search().list(
         part="snippet",
         channelId=os.environ.get('SNCRS_YOUTUBE_CHANNEL_ID'),
         maxResults=50,
-        q=search_string,
+        q=title,
         type="video"
     )
     response = request.execute()

--- a/sncrs/data/youtube_logic.py
+++ b/sncrs/data/youtube_logic.py
@@ -6,91 +6,6 @@ import googleapiclient.errors
 
 from .models import SmashNight, Match
 
-
-def get_night_count(sn=None, match=None):
-    night = 0
-    if sn is not None:
-        earliest_smash_night = SmashNight.objects.filter(season=sn.season).order_by('night_count')[0]
-        night = sn.night_count - earliest_smash_night.night_count + 1
-    elif match is not None:
-        earliest_smash_night = SmashNight.objects.filter(season=match.sn.season).order_by('night_count')[0]
-        night = match.sn.night_count - earliest_smash_night.night_count + 1
-    return night
-
-
-# get the match title for YouTube
-def get_match_title(match):
-    title = ""
-    bracket_format = "STL SmashNight {season}.{night} {bracket_title} {win_lose} "\
-        "Round {round}- {team_1} | {p1}({p1_main}) vs {team_2} | {p2}({p2_main})"
-    challenge_format = "STL SmashNight {season}.{night} "\
-        "Challenge Match- {team_1} | {p1}({p1_main}) vs {team_2} | {p2}({p2_main})"
-    if match.type == Match.BRACKET:
-        title = bracket_format.format(
-            season=match.sn.season,
-            night=get_night_count(match=match),
-            bracket_title=match.bracket.title,
-            win_lose="Winners" if match.round > 0 else "Losers" if match.round < 0 else "",
-            round=abs(match.round),
-            team_1=match.p1.team.tag,
-            team_2=match.p2.team.tag,
-            p1=match.p1.display_name,
-            p2=match.p2.display_name,
-            p1_main=match.p1.main_1.name if match.p1.main_1 is not None else "",
-            p2_main=match.p2.main_1.name if match.p2.main_1 is not None else ""
-        )
-    elif match.type == Match.CHALLENGE:
-        title = challenge_format.format(
-            season=match.sn.season,
-            night=get_night_count(match=match),
-            team_1=match.p1.team.tag,
-            team_2=match.p2.team.tag,
-            p1=match.p1.display_name,
-            p2=match.p2.display_name,
-            p1_main=match.p1.main_1.name if match.p1.main_1 is not None else "",
-            p2_main=match.p2.main_1.name if match.p2.main_1 is not None else ""
-
-        )
-    return title
-
-
-# get the match description for YouTube
-def get_match_description(match):
-    desc = ""
-    if match.type == Match.BRACKET:
-        desc = "S{season}T{night} | {bracket_title}, {win_lose} Round {round} | {p1} vs {p2}".format(
-            season=match.sn.season,
-            night=get_night_count(match=match),
-            bracket_title=match.bracket.title,
-            win_lose="Winners" if match.round > 0 else "Losers" if match.round < 0 else "",
-            round=abs(match.round),
-            p1=match.p1.display_name,
-            p2=match.p2.display_name
-        )
-    elif match.type == Match.CHALLENGE:
-        desc = "S{season}T{night} | Challenge Match | {p1} vs {p2}".format(
-            season=match.sn.season,
-            night=get_night_count(match=match),
-            p1=match.p1.display_name,
-            p2=match.p2.display_name
-        )
-
-    return desc
-
-
-# get title and description for all matches
-def get_titles_and_descriptions(sn):
-    all_details = []
-    for match in sn.match_set.all():
-        all_details.append(
-            {
-                "Title": get_match_title(match),
-                "Description": get_match_description(match)
-            }
-        )
-    return all_details
-
-
 # get the round number given the Description
 def get_round_number(description):
     extracted_round = re.search(r'(?<=round )\d', description)
@@ -145,7 +60,7 @@ def get_possible_matches(video, sn):
         p2_names.extend([alias.name for alias in match.p2.alias_set.all()])
         # Check if the description and title matches
         if any(item.lower() in title for item in p1_names) and any(item.lower() in title for item in p2_names):
-            if get_match_description(match).lower() in description:
+            if match.description.lower() in description:
                 matches.append(match)
 
     return matches


### PR DESCRIPTION
This one spiraled a little:
### For SmashNight model
- Added to the SmashNight model so that we can get the short title (like 5.2) directly from a queryset
- Added utility to auto-generate smashnight name on initial save
### For the API
- Added the smashnights endpoint
- Expanded and cleaned up the match filters to allow querying on multiple individuals, as well as on a SmashNight's short_title
### For Matches (Stole work from @coltatgh and expanded)
- Added winners_index, losers_index, round_name, title, and description as annotations on the Match Queryset so that we can get them directly
- Removed the sections of youtube_logic that are no longer needed
### For quickstart
- Added the logs command