### PR TITLE
Fix backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,31 @@ Then, the magic happens! Voila!
 
 ### Set up backups
 
-Note: This will only back up the production postgres container
+```bash
+./qs backup install <prod|dev>
+```
+
+### Update the backup script without changing the cron job
 
 ```bash
-./qs backup install
+./qs backup update <prod|dev>
 ```
 
 ### Back up immediately
 
 ```bash
-./qs backup now
+./qs backup now <prod|dev> [local_file_location]
 ```
+
+If local_file_location is provided, the backup file will be placed in that location. This is ideal for local testing
+
+### Restore from a backup
+
+```bash
+./qs backup restore <prod|dev> [file_location]
+```
+
+The backup will be restored to the specified container (prod|dev). Note that this includes media files and all database info.
+This will clear out existing data, so be careful!
 
 ## Long Live SmashNights!

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -2,18 +2,33 @@
 
 set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+con_type=${1:-prod}
+local_file_dest=$2
 
 WORK_DIR=$(mktemp -d)
 trap "rm -rf $WORK_DIR" EXIT
 
-. $SCRIPT_DIR/.env
-sncrs_postgres_container=$(docker container ls | grep 'sncrs_prod[^ ]*db' | head -n 1 | cut -f1,1 -d" ")
+. $SCRIPT_DIR/.env.${con_type}
+sncrs_postgres_container=$(docker container ls | grep 'sncrs_'"$con_type"'[^ ]*db' | head -n 1 | cut -f1,1 -d" ")
 if [ -z $sncrs_postgres_container ]; then
     echo "Error: The sncrs postgres container is not available, can't backup"
     exit 1
 fi
-BACKUP_FILE_PATH=${WORK_DIR}/sncrs-$(date '+%Y%m%d-%H%M').gz
-docker exec ${sncrs_postgres_container} pg_dump -c -U ${POSTGRES_USER} -d ${POSTGRES_DB} | gzip > $BACKUP_FILE_PATH
-for dest in "$RCLONE_DESTS"; do
-    rclone -vv --no-check-dest copy "${BACKUP_FILE_PATH}" "${dest}"
-done
+BACKUP_FILE_NAME="sncrs-$con_type-$(date '+%Y%m%d-%H%M').tar.gz"
+BACKUP_FILE_PATH=${WORK_DIR}/${BACKUP_FILE_NAME}
+DB_BACKUP_PATH=${WORK_DIR}/sncrs-db.sql
+docker exec ${sncrs_postgres_container} pg_dumpall -c -U ${POSTGRES_USER} > $DB_BACKUP_PATH
+sncrs_web_container=$(docker container ls | grep 'sncrs_'"$con_type"'[^ ]*web' | head -n 1 | cut -f1,1 -d" ")
+if [ -z $sncrs_web_container ]; then
+    echo "Error: The sncrs web container is not available, can't backup"
+    exit 1
+fi
+# Copy the media files into the backup location
+docker run -v ${WORK_DIR}:/backup --rm --volumes-from $sncrs_web_container ubuntu bash -c "cp -r /sncrs/media /backup/media && chmod -R 777 /backup && tar czf /tmp/${BACKUP_FILE_NAME} /backup && cp /tmp/${BACKUP_FILE_NAME} /backup/"
+if [ -n "$local_file_dest" ]; then
+    cp "${BACKUP_FILE_PATH}" "${local_file_dest}"
+else
+    for dest in "$RCLONE_DESTS"; do
+        rclone -vv --no-check-dest copy "${BACKUP_FILE_PATH}" "${dest}"
+    done
+fi

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -24,11 +24,13 @@ if [ -z $sncrs_web_container ]; then
     exit 1
 fi
 # Copy the media files into the backup location
-docker run -v ${WORK_DIR}:/backup --rm --volumes-from $sncrs_web_container ubuntu bash -c "cp -r /sncrs/media /backup/media && chmod -R 777 /backup && tar czf /tmp/${BACKUP_FILE_NAME} /backup && cp /tmp/${BACKUP_FILE_NAME} /backup/"
+docker run -v ${WORK_DIR}:/backup --rm --volumes-from $sncrs_web_container ubuntu bash -c \
+"cp -r /sncrs/media /backup/media && chmod -R 777 /backup && tar czf /tmp/${BACKUP_FILE_NAME} /backup && cp /tmp/${BACKUP_FILE_NAME} /backup/"
 if [ -n "$local_file_dest" ]; then
     cp "${BACKUP_FILE_PATH}" "${local_file_dest}"
 else
     for dest in "$RCLONE_DESTS"; do
         rclone -vv --no-check-dest copy "${BACKUP_FILE_PATH}" "${dest}"
+        rclone delete "${dest}" --min-age 1w --max-depth 1 --include '*sncrs*'
     done
 fi

--- a/qs
+++ b/qs
@@ -49,23 +49,55 @@ fi
 ## Backup Commands ##
 if [ $category == "backup" ]; then
     action=$2
-    . "config/.env.prod"
-    if [ $action == "install" ]; then
+    con_type=${3:-prod}
+    config_file="config/.env.${con_type}"
+    . $config_file
+    case $action in
+    install|update)
         mkdir -p $SNCRS_BACKUP_DIR
-        cp "config/.env.prod" $SNCRS_BACKUP_DIR/.env
+        cp $config_file $SNCRS_BACKUP_DIR/
         script_location=$SNCRS_BACKUP_DIR/backup.sh 
         cp "backup/backup.sh" $script_location
-        if crontab -l | grep -q $script_location ; then
+        ;;&
+    install)
+        if crontab -l | grep -q "$script_location $con_type" ; then
             echo "Cron job already installed"
         else
-            (crontab -l 2>/dev/null; echo "0 12 * * * $script_location") | crontab -
+            (crontab -l 2>/dev/null; echo "0 12 * * * $script_location $con_type") | crontab -
         fi
-    elif [ $action == "now" ]; then
+        ;;
+    now)
+        local_file="$4"
         script_location="$SNCRS_BACKUP_DIR/backup.sh"
         if [ -f $script_location ]; then
-            $script_location
+            $script_location $con_type $local_file
         else
             echo "Backup script is not correctly placed, please run 'qs backup install'"
         fi
-    fi
+        ;;
+    restore)
+        backup_file_location="$4"
+        if ! [ -e $backup_file_location ]; then
+            echo "Error: There is no file available at $backup_file_location"
+            exit 1
+        fi
+        sncrs_postgres_container=$(docker container ls | grep "sncrs_$con_type"'[^ ]*db' | head -n 1 | cut -f1,1 -d" ")
+        if [ -z $sncrs_postgres_container ]; then
+            echo "Error: The sncrs postgres container is not available, can't restore backup"
+            exit 1
+        fi
+        sncrs_web_container=$(docker container ls | grep "sncrs_$con_type"'[^ ]*web' | head -n 1 | cut -f1,1 -d" ")
+        if [ -z $sncrs_web_container ]; then
+            echo "Error: The sncrs web container is not available, can't restore backup"
+            exit 1
+        fi
+        WORK_DIR=$(mktemp -d)
+        trap "rm -rf $WORK_DIR" EXIT
+        cp $backup_file_location $WORK_DIR/restore.tar.gz
+        tar xzf $WORK_DIR/restore.tar.gz -C $WORK_DIR
+        docker cp $WORK_DIR/backup/media/. $sncrs_web_container:/sncrs/media/.
+        docker exec $sncrs_web_container chown -R www-data:www-data /sncrs/media
+        cat $WORK_DIR/backup/sncrs-db.sql | docker exec -i $sncrs_postgres_container psql -U $POSTGRES_USER -d postgres
+        ;;
+    esac
 fi


### PR DESCRIPTION
This should close #22 and fix the backups.
This now includes the media files (images uploaded by the user), and utilizes pg_dumpall to get all of the data out of postgres, rather than just our specific database. This means we can now get an identical state for the whole database.

Due to that process being slightly more involved with the new format, I scripted it.
@coltatgh if you are up for testing, I'm gonna send you a link to a full backup, have you checkout this branch and then run 
```bash
./qs run dev
./qs backup restore dev <path_to_the_downloaded_file>
```

After that is done, your local dev instance should be identical to the production sncrs!